### PR TITLE
Ocamlbuild plugin

### DIFF
--- a/META
+++ b/META
@@ -1,0 +1,8 @@
+description = "Cppo ocamlbuild plugin"
+version = "dev"
+
+requires = "ocamlbuild"
+archive(byte) = "ocamlbuild_cppo.cma"
+archive(byte, plugin) = "ocamlbuild_cppo.cma"
+archive(native) = "ocamlbuild_cppo.cmxa"
+archive(native, plugin) = "ocamlbuild_cppo.cmxs"

--- a/README.md
+++ b/README.md
@@ -359,6 +359,38 @@ Printf.printf ">>> %s\n" "print_endline"; print_endline "Hello"
 `STRINGIFY(x)` is the equivalent of `#x` in cpp syntax.
 
 
+Ocamlbuild plugin
+------------------
+
+An ocamlbuild plugin is available. To use it, you can call ocamlbuild with the argument `--plugin-tag package(cppo_ocamlbuild)` (only since 4.01).
+
+With Oasis :
+```
+OCamlVersion: >= 4.01
+AlphaFeatures: ocamlbuild_more_args
+XOCamlbuildPluginTags: package(cppo_ocamlbuild)
+```
+
+After that, you need to add in your `myocamlbuild.ml` :
+```ocaml
+let () =
+  Ocamlbuild_plugin.dispatch
+    (fun hook ->
+      Ocamlbuild_cppo.dispatcher hook ;
+    )
+```
+
+The plugin will apply cppo on all files ending in `.cppo.ml` in order to produce`.ml` files. The following tags are available:
+* `cppo_D(X)` ≡ `-D X`
+* `cppo_U(X)` ≡ `-U X`
+* `cppo_q` ≡ `-q`
+* `cppo_s` ≡ `-s`
+* `cppo_n` ≡ `-n`
+* `cppo_x(NAME:CMD_TEMPLATE)` ≡ `-x NAME:CMD_TEMPLATE`
+* The tag `cppo_I(foo)` can behave in two way:
+  * If `foo` is a directory, it's equivalent to `-I foo`.
+  * If `foo` is a file, it adds `foo` as a dependency and apply `-I parent(foo)`.
+
 Detailed command-line usage and options
 ---------------------------------------
 

--- a/ocamlbuild_plugin/_tags
+++ b/ocamlbuild_plugin/_tags
@@ -1,0 +1,1 @@
+true: package(ocamlbuild)

--- a/ocamlbuild_plugin/ocamlbuild_cppo.ml
+++ b/ocamlbuild_plugin/ocamlbuild_cppo.ml
@@ -1,0 +1,30 @@
+
+open Ocamlbuild_plugin
+
+let dispatcher = function
+  | After_rules -> begin
+      let dep = "%(name).cppo.ml" in
+      let prod1 = "%(name: <*> and not <*.cppo>).ml" in
+      let prod2 = "%(name: <**/*> and not <**/*.cppo>).ml" in
+      let f prod env _build =
+        let dep = env dep in
+        let prod = env prod in
+        let tags = tags_of_pathname prod ++ "cppo" in
+        Cmd (S[A "cppo"; T tags; S [A "-o"; P prod]; P dep ])
+      in
+      rule "cppo1" ~dep ~prod:prod1 (f prod1) ;
+      rule "cppo2" ~dep ~prod:prod2 (f prod2) ;
+      pflag ["cppo"] "cppo_D" (fun s -> S [A "-D"; A s]) ;
+      pflag ["cppo"] "cppo_U" (fun s -> S [A "-U"; A s]) ;
+      pflag ["cppo"] "cppo_I" (fun s ->
+        if Pathname.is_directory s then S [A "-I"; P s]
+        else S [A "-I"; P (Pathname.dirname s)]
+      ) ;
+      pdep ["cppo"] "cppo_I" (fun s ->
+        if Pathname.is_directory s then [] else [s]) ;
+      flag ["cppo"; "cppo_q"] (A "-q") ;
+      flag ["cppo"; "cppo_s"] (A "-s") ;
+      flag ["cppo"; "cppo_s"] (A "-n") ;
+      pflag ["cppo"] "cppo_x" (fun s -> S [A "-x"; A s])
+    end
+  | _ -> ()

--- a/ocamlbuild_plugin/ocamlbuild_cppo.mli
+++ b/ocamlbuild_plugin/ocamlbuild_cppo.mli
@@ -1,0 +1,2 @@
+
+val dispatcher : Ocamlbuild_plugin.hook -> unit

--- a/opam
+++ b/opam
@@ -1,0 +1,13 @@
+opam-version: "1"
+maintainer: "contact@ocamlpro.com"
+authors: ["Martin Jambon"]
+homepage: "http://mjambon.com/cppo.html"
+license: "BSD-3-Clause"
+build: [
+  [make]
+  [make "install-lib"]
+]
+
+remove: [
+  ["ocamlfind" "remove" "cppo_ocamlbuild"]
+]


### PR DESCRIPTION
I did a small ocamlbuild plugin, it uses cppo on files `.cppo.ml` to produce `.ml`. The documentation is in the Readme.

It seems to work nicely (see [this](https://github.com/Drup/LILiS/blob/cppo/myocamlbuild.ml#L14)), few remarks: 
- I need to test it a bit more.
- I may add a test/example.
- there is no tag for the -x option, I will add it later.
- I'm not convinced by the name choices for the tags, if you have better ideas, I will happily change the names.
- the opam file need to be changed, so I added it directly in the repository (which allows pinning).
- I'm completely terrible at makefiles, I have no idea how they work and I'm not sure I want to spoil my brain with this knowledge. I put together something using pieces of js_of_ocaml's makefile, it works, but I will be very happy if you want to rewrite it differently.

cc @hhugo
