### PR TITLE
Make cppo safe-string ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,14 @@ ML = cppo_version.ml cppo_types.ml \
 OCAMLBUILD_ML = ocamlbuild_cppo.ml
 
 all: $(ML)
-	ocamlc -o cppo$(EXE) -dtypes unix.cma str.cma $(ML)
+	ocamlfind ocamlc -o cppo$(EXE) -dtypes -linkpkg -package "unix str bytes" $(ML)
 
 opt: $(ML)
-	ocamlopt -o cppo$(EXE) -dtypes unix.cmxa str.cmxa $(ML)
+	ocamlfind ocamlopt -o cppo$(EXE) -dtypes -linkpkg -package "unix str bytes" $(ML)
 
 # For debugging; not installed.
 toplib: $(ML)
-	ocamlc -a -o cppo.cma -dtypes unix.cma str.cma $(ML)
+	ocamlfind ocamlc -a -o cppo.cma -dtypes -linkpkg -package "unix str bytes" $(ML)
 
 ocamlbuild:
 	cd ocamlbuild_plugin && ocamlbuild -use-ocamlfind $(OCAMLBUILD_IMPL)

--- a/cppo_lexer.mll
+++ b/cppo_lexer.mll
@@ -19,7 +19,7 @@ let lex_new_lines lb =
   let n = ref 0 in
   let s = lb.lex_buffer in
   for i = lb.lex_start_pos to lb.lex_curr_pos do
-    if s.[i] = '\n' then
+    if Bytes.get s i = '\n' then
       incr n
   done;
   let p = lb.lex_curr_p in

--- a/opam
+++ b/opam
@@ -4,10 +4,21 @@ authors: ["Martin Jambon"]
 homepage: "http://mjambon.com/cppo.html"
 license: "BSD-3-Clause"
 build: [
-  [make]
+  [make "all"] {!ocaml_native}
+  [make "opt"] {ocaml_native}
+  [make "ocamlbuild"]
+]
+
+install: [
   [make "install-lib"]
 ]
 
 remove: [
   ["ocamlfind" "remove" "cppo_ocamlbuild"]
+]
+
+depends: [
+  "ocamlfind"
+  "ocamlbuild"
+  "base-bytes"
 ]


### PR DESCRIPTION
This is helpful to be able to compile cppo with OCaml 4.04.0+safe-string (-safe-string enabled at configure time).