### PR TITLE
Remove base-bytes dependency

### DIFF
--- a/cppo.opam
+++ b/cppo.opam
@@ -16,6 +16,5 @@ build-test: [
 
 depends: [
   "jbuilder" {build & >= "1.0+beta17"}
-  "base-bytes"
   "base-unix"
 ]


### PR DESCRIPTION
It's already present on ocaml >= 4.02 and since we use dune we will not build on
anything lower.