### PR TITLE
ci: generate the .opam files first

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,10 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-version }}
 
       - name: Install dependencies
-        run: opam install --deps-only .
+        run: |
+          opam install dune
+          opam exec -- dune build cppo.opam cppo_ocamlbuild.opam
+          opam install --deps-only .
 
       - name: List installed packages
         run: opam list


### PR DESCRIPTION
I've also disabled direct pushes to the master branch---now PR only.